### PR TITLE
[US-7]: UI of steps to generate video

### DIFF
--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react";
 import type { MediaPresenter } from "../MediaPresenter";
+import type { OutputPresenter } from "../../OutputPresenter";
 import { Container, Col, Row } from "react-bootstrap";
 import { ErrorToast } from "../ErrorToast/ErrorToast";
 import styles from "./Modal.module.css";
@@ -9,6 +10,7 @@ type Props = {
   mediaPresenter: MediaPresenter;
   modalOpen: boolean;
   closeModal: () => void;
+  outputPresenter: OutputPresenter;
 };
 
 export const Modal: React.FC<Props> = observer(
@@ -38,6 +40,13 @@ export const Modal: React.FC<Props> = observer(
                 <h3>Create a Video</h3>
               </Row>
               <Row className={styles.steps}>
+              <Steps
+                  outputPresenter={outputPresenter}
+                  stepNumber={stepNumber}
+                  mediaPresenter={mediaPresenter}
+                  closePlayerModal={closePlayerModal}
+                  openPlayerModal={openPlayerModal}
+                />
               </Row>
             </Col>
             <Col className={styles.modalBody} sm={8}>

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { observer } from "mobx-react";
-import type { MediaPresenter } from "../MediaPresenter";
+import type { MediaPresenter } from "../../MediaPresenter";
 import type { OutputPresenter } from "../../OutputPresenter";
 import { Container, Col, Row } from "react-bootstrap";
 import { ErrorToast } from "../ErrorToast/ErrorToast";
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export const Modal: React.FC<Props> = observer(
-  ({ mediaPresenter, modalOpen, closeModal}) => {
+  ({ mediaPresenter, modalOpen, closeModal, outputPresenter}) => {
     const windowModal = (
       event: React.MouseEvent<HTMLDivElement, MouseEvent>
     ): void => {
@@ -42,7 +42,6 @@ export const Modal: React.FC<Props> = observer(
               <Row className={styles.steps}>
               <Steps
                   outputPresenter={outputPresenter}
-                  stepNumber={stepNumber}
                   mediaPresenter={mediaPresenter}
                   closePlayerModal={closePlayerModal}
                   openPlayerModal={openPlayerModal}

--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -6,20 +6,33 @@ import { Container, Col, Row } from "react-bootstrap";
 import { ErrorToast } from "../ErrorToast/ErrorToast";
 import styles from "./Modal.module.css";
 import classnames from "classnames";
+import { Steps } from "../Steps/Steps";
+
 type Props = {
   mediaPresenter: MediaPresenter;
+  outputPresenter: OutputPresenter;
   modalOpen: boolean;
   closeModal: () => void;
-  outputPresenter: OutputPresenter;
 };
 
 export const Modal: React.FC<Props> = observer(
-  ({ mediaPresenter, modalOpen, closeModal, outputPresenter}) => {
+  ({ mediaPresenter, modalOpen, closeModal, outputPresenter }) => {
+    const [openPlayer, setOpenPlayer] = useState<boolean>(false);
     const windowModal = (
       event: React.MouseEvent<HTMLDivElement, MouseEvent>
     ): void => {
       event.stopPropagation();
     };
+
+    const openPlayerModal = () => {
+      setOpenPlayer(true);
+    };
+
+    const closePlayerModal = () => {
+      outputPresenter.pauseVideo();
+      setOpenPlayer(false);
+    };
+
     return (
       <div
         className={classnames(styles.modal, { [styles.open]: modalOpen })}
@@ -40,7 +53,7 @@ export const Modal: React.FC<Props> = observer(
                 <h3>Create a Video</h3>
               </Row>
               <Row className={styles.steps}>
-              <Steps
+                <Steps
                   outputPresenter={outputPresenter}
                   mediaPresenter={mediaPresenter}
                   closePlayerModal={closePlayerModal}
@@ -48,8 +61,7 @@ export const Modal: React.FC<Props> = observer(
                 />
               </Row>
             </Col>
-            <Col className={styles.modalBody} sm={8}>
-            </Col>
+            <Col className={styles.modalBody} sm={8}></Col>
           </Row>
         </Container>
       </div>

--- a/src/Components/Steps/Steps.module.css
+++ b/src/Components/Steps/Steps.module.css
@@ -1,0 +1,149 @@
+.stepsContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.steppingContainer {
+  display: flex;
+  flex-direction: row;
+  cursor: pointer;
+  /* align-items: flex-start; */
+  /* justify-content: flex-start; */
+}
+.disbContainer {
+  position: relative;
+  margin: 10px -10px;
+  height: 45px;
+}
+
+.disbSteppingContainer {
+  position: absolute;
+  height: 50px;
+  left: 0;
+  background-color: var(--disabled-grey-background);
+  display: flex;
+  width: 200%;
+  border-radius: 5px;
+  font-weight: 500;
+  padding: 10px 0;
+}
+.stepNumber {
+  background-color: var(--purple);
+  width: 25px;
+  height: 25px;
+  margin-right: 7px;
+  text-align: center;
+  color: var(--white);
+  border-radius: 50%;
+  display: inline-block;
+}
+.stepText {
+  color: var(--black);
+  display: inline-block;
+}
+.disbStepNumber {
+  width: 25px;
+  height: 25px;
+  margin-right: 7px;
+  text-align: center;
+  color: var(--disabled-grey-text);
+  border: solid 1px var(--disabled-grey-text);
+  border-radius: 50%;
+  display: inline-block;
+  margin: 0 8px;
+}
+.disbStepText {
+  color: var(--disabled-grey-text);
+  display: inline-block;
+}
+
+.uploadBtnCont {
+  position: relative;
+  margin-bottom: 35px;
+  /* height: 45px; */
+  left: -20px;
+  border: 0;
+  background-color: white;
+}
+
+.uploadBtn {
+  position: absolute;
+  height: 45px;
+  left: 0;
+  background-color: var(--purple);
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  width: 310px;
+  border-radius: 5px;
+  font-weight: 500;
+  color: var(--white);
+  cursor: pointer;
+}
+
+.clickedUploadBtn {
+  position: absolute;
+  height: 45px;
+  left: 0;
+  background-color: var(--lightgrey);
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  width: 310px;
+  border-radius: 5px;
+  font-weight: 500;
+  color: var(--black);
+  cursor: pointer;
+}
+
+.continueBtn {
+  position: relative;
+  height: 45px;
+  background-color: var(--purple);
+  width: 310px;
+  border: 0;
+  border-radius: 5px;
+  font-weight: 500;
+  color: var(--white);
+  margin-bottom: 10px;
+  left: -20px;
+}
+
+
+.downArrow {
+  border: solid black;
+  border-width: 0 2px 2px 0;
+  display: inline-block;
+  padding: 0.25rem;
+  transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
+  position: absolute;
+  right: 25px;
+  margin-top: 5px;
+  cursor: pointer;
+}
+
+.upArrow {
+  border: solid black;
+  border-width: 0 2px 2px 0;
+  display: inline-block;
+  padding: 0.25rem;
+  transform: rotate(-135deg);
+  -webkit-transform: rotate(-135deg);
+  position: absolute;
+  right: 25px;
+  margin-top: 5px;
+  cursor: pointer;
+}
+
+.disabledUpArrow {
+  border: solid var(--disabled-grey-text);
+  border-width: 0 2px 2px 0;
+  display: inline-block;
+  padding: 0.25rem;
+  transform: rotate(-135deg);
+  -webkit-transform: rotate(-135deg);
+  position: absolute;
+  right: 25px;
+  margin-top: 5px;
+}

--- a/src/Components/Steps/Steps.tsx
+++ b/src/Components/Steps/Steps.tsx
@@ -28,9 +28,7 @@ export const Steps: React.FC<Props> = observer(
 
     const [stepOneOpen, setStepOneOpen] = useState<boolean>(true);
     const [stepTwoOpen, setStepTwoOpen] = useState<boolean>(false);
-    const AddFile = () => {
-      return <div></div>;
-    };
+
     return (
       <div className={styles.stepsContainer}>
         <div

--- a/src/Components/Steps/Steps.tsx
+++ b/src/Components/Steps/Steps.tsx
@@ -135,7 +135,7 @@ export const Steps: React.FC<Props> = observer(
         </div>
             {
                 mediaPresenter.mediaReady && stepTwoOpen &&
-                (<Mood outputPresenter={outputPresenter} mediaPresenter={mediaPresenter}/>)
+                (<p>buttons buttons here</p>)
             }
       </div>
     );

--- a/src/Components/Steps/Steps.tsx
+++ b/src/Components/Steps/Steps.tsx
@@ -6,7 +6,6 @@ import type { OutputPresenter } from "../../OutputPresenter";
 import { showError } from "../ErrorToast/ErrorToast";
 
 type Props = {
-  stepNumber: number;
   mediaPresenter: MediaPresenter;
   outputPresenter: OutputPresenter;
   openPlayerModal: () => void;
@@ -14,7 +13,7 @@ type Props = {
 };
 
 export const Steps: React.FC<Props> = observer(
-  ({ stepNumber, mediaPresenter, outputPresenter, openPlayerModal, closePlayerModal }) => {
+  ({ mediaPresenter, outputPresenter, openPlayerModal, closePlayerModal }) => {
     const handleMediaUpload = async (
       event: React.ChangeEvent<HTMLInputElement>
     ) => {

--- a/src/Components/Steps/Steps.tsx
+++ b/src/Components/Steps/Steps.tsx
@@ -1,0 +1,144 @@
+import React, { useState } from "react";
+import { observer } from "mobx-react";
+import styles from "./Steps.module.css";
+import type { MediaPresenter } from "../../MediaPresenter";
+import type { OutputPresenter } from "../../OutputPresenter";
+import { showError } from "../ErrorToast/ErrorToast";
+
+type Props = {
+  stepNumber: number;
+  mediaPresenter: MediaPresenter;
+  outputPresenter: OutputPresenter;
+  openPlayerModal: () => void;
+  closePlayerModal: () => void;
+};
+
+export const Steps: React.FC<Props> = observer(
+  ({ stepNumber, mediaPresenter, outputPresenter, openPlayerModal, closePlayerModal }) => {
+    const handleMediaUpload = async (
+      event: React.ChangeEvent<HTMLInputElement>
+    ) => {
+      if (event.target.files === null) return;
+      const files: FileList = event.target.files;
+      Array.from(files).forEach((file: File) => {
+        if (!mediaPresenter.addFile(file)) {
+          showError(file.name + "is not an acceptable file format");
+        }
+      });
+    };
+
+    const [stepOneOpen, setStepOneOpen] = useState<boolean>(true);
+    const [stepTwoOpen, setStepTwoOpen] = useState<boolean>(false);
+    const AddFile = () => {
+      return <div></div>;
+    };
+    return (
+      <div className={styles.stepsContainer}>
+        <div
+          className={styles.steppingContainer}
+          onClick={() => {
+            if (mediaPresenter.mediaReady) {
+              if(!stepOneOpen) {
+                setStepOneOpen(true);
+              }
+              closePlayerModal();
+            }         
+          }}
+        >
+          <span className={styles.stepNumber}>1</span>
+
+          <p className={styles.stepText}>Add your files</p>
+          <span onClick={()=> {
+            setStepOneOpen(!stepOneOpen);
+          }}>
+            <i className={stepOneOpen ? styles.downArrow : styles.upArrow}></i>
+          </span>
+        </div>
+
+        {stepOneOpen && (
+          <button className={styles.uploadBtnCont}>
+            <label htmlFor="fileUpload">
+              <div className={mediaPresenter.mediaReady ? styles.clickedUploadBtn : styles.uploadBtn }>Upload media</div>
+            </label>
+            <input
+              hidden
+              multiple
+              id="fileUpload"
+              type="file"
+              accept="video/* image/*"
+              onChange={handleMediaUpload}
+            />
+          </button>
+        )}
+          { stepOneOpen &&
+            mediaPresenter.mediaReady &&
+        <button className={styles.continueBtn}
+            onClick={()=> {
+              if(!stepTwoOpen) {
+                setStepTwoOpen(true);
+                setStepOneOpen(false);
+                openPlayerModal();
+              }
+            }}
+          >Continue</button>
+          }
+        <div
+          className={
+            mediaPresenter.mediaReady
+              ? styles.steppingContainer
+              : styles.disbContainer
+          }
+          onClick={() => {
+            if (mediaPresenter.mediaReady) {
+              if(!stepTwoOpen) {
+                setStepTwoOpen(true);
+              }
+                openPlayerModal();
+            }
+        }}
+        >
+          <div
+            className={
+              mediaPresenter.mediaReady
+                ? undefined
+                : styles.disbSteppingContainer
+            }
+          >
+            <span
+              className={
+                mediaPresenter.mediaReady
+                  ? styles.stepNumber
+                  : styles.disbStepNumber
+              }
+            >
+              2
+            </span>
+            <p
+              className={
+                mediaPresenter.mediaReady
+                  ? styles.stepText
+                  : styles.disbStepText
+              }
+            >
+              Customise your video
+            </p>
+            <span>
+              <i
+                className={
+                  mediaPresenter.mediaReady
+                    ? stepTwoOpen ? styles.downArrow : styles.upArrow
+                    : styles.disabledUpArrow
+                }
+                onClick={() => {setStepTwoOpen(!stepTwoOpen)}}
+              ></i>
+            </span>
+          </div>
+        </div>
+            {
+                mediaPresenter.mediaReady && stepTwoOpen &&
+                (<Mood outputPresenter={outputPresenter} mediaPresenter={mediaPresenter}/>)
+            }
+      </div>
+    );
+  }
+);

--- a/src/Components/Steps/Steps.tsx
+++ b/src/Components/Steps/Steps.tsx
@@ -14,6 +14,8 @@ type Props = {
 
 export const Steps: React.FC<Props> = observer(
   ({ mediaPresenter, outputPresenter, openPlayerModal, closePlayerModal }) => {
+    const [stepOneOpen, setStepOneOpen] = useState<boolean>(true);
+    const [stepTwoOpen, setStepTwoOpen] = useState<boolean>(false);
     const handleMediaUpload = async (
       event: React.ChangeEvent<HTMLInputElement>
     ) => {
@@ -26,21 +28,20 @@ export const Steps: React.FC<Props> = observer(
       });
     };
 
-    const [stepOneOpen, setStepOneOpen] = useState<boolean>(true);
-    const [stepTwoOpen, setStepTwoOpen] = useState<boolean>(false);
+    const onStepClick = () => {
+      if (mediaPresenter.mediaReady) {
+        if(!stepOneOpen) {
+          setStepOneOpen(true);
+        }
+        closePlayerModal();
+      } 
+    }
 
     return (
       <div className={styles.stepsContainer}>
         <div
           className={styles.steppingContainer}
-          onClick={() => {
-            if (mediaPresenter.mediaReady) {
-              if(!stepOneOpen) {
-                setStepOneOpen(true);
-              }
-              closePlayerModal();
-            }         
-          }}
+          onClick={onStepClick}
         >
           <span className={styles.stepNumber}>1</span>
 


### PR DESCRIPTION
This PR is the start of restructuring steps UI of the project's design. This will be the general lay out of the left side of the modal.

changes include:
- shows which step a user is at while creating a video
- calls functions from media presenter to check if media is ready
- steps panel is able to open and close video player (named as playermodal)

Intended design:
https://www.figma.com/file/bol9SiTfZktGz4MnpDan1c/Intern-Project-Magic-Video-Auto-Composition?node-id=4%3A11035

With this PR, the steps will look as below:
<img width="176" alt="Screen Shot 2021-02-12 at 12 42 19" src="https://user-images.githubusercontent.com/44097068/107721043-c0c5a180-6d2f-11eb-8f18-857471c56e7a.png">

